### PR TITLE
Remove caller skip from BuildForCtrl

### DIFF
--- a/zaputil/zaputil.go
+++ b/zaputil/zaputil.go
@@ -65,13 +65,11 @@ func (fc *FlagConfig) GetConfig() zap.Config {
 }
 
 // BuildForCtrl returns a zap.Logger built to work well with the controller-runtime.
+// Note: using the controller-runtime logger directly will not record the correct
+// filename/line - instead, call `WithName` or `WithValues` in your function, and
+// use the resulting logger.
 func (fc *FlagConfig) BuildForCtrl() (*zap.Logger, error) {
-	logger, err := fc.GetConfig().Build()
-	if err != nil {
-		return logger, err
-	}
-
-	return logger.WithOptions(zap.AddCallerSkip(1)), nil
+	return fc.GetConfig().Build()
 }
 
 // BuildForKlog returns a zap.Logger built from given config, made to work well with klog. The


### PR DESCRIPTION
The previous behavior was good for cases where the logger was stored in
a global variable and used directly, _without_ calling `WithName` or
`WithValues` inside a function. However, if one of those methods is
called, the resulting logger will not record the correct function, file,
and line number.

It does not seem feasible to make it work correctly in both cases.

Since using `WithValues` in a function is very useful, and it is not a
big burden to use `WithName` in a function instead of just using a
global logger directly, the new behavior should be better.

The documentation/example have been updated to reflect the proper
usage, and warn about this situation.

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>